### PR TITLE
deps: upgrade Go to 1.25.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches: [ "master" ]
 
 env:
-  GO_VERSION: '1.25.7'
+  GO_VERSION: '1.25.8'
   REGISTRY: ghcr.io
   IMAGE_NAME: drakkarstorm/deadlinkr
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.8'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,7 @@ jobs:
       - name: 🐹 Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.8'
 
       - name: 🏗️ Build application
         run: |
@@ -67,7 +67,7 @@ jobs:
       - name: 🐹 Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.8'
 
       - name: 🛡️ Run Gosec Security Scanner (SARIF)
         uses: securego/gosec@master
@@ -111,7 +111,7 @@ jobs:
       - name: 🐹 Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.8'
 
       - name: 🔍 Run govulncheck vulnerability scanner
         uses: golang/govulncheck-action@v1
@@ -163,7 +163,7 @@ jobs:
       - name: 🐹 Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.8'
 
       - name: 🔒 Install go-licenses
         run: go install github.com/google/go-licenses@latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ==============================================================================
 # Build Stage
 # ==============================================================================
-FROM golang:1.25.7-alpine AS builder
+FROM golang:1.25.8-alpine AS builder
 
 # Install build dependencies
 # Use --no-scripts to avoid busybox trigger issues with QEMU emulation

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DrakkarStorm/deadlinkr
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.2


### PR DESCRIPTION
Fixes stdlib vulnerabilities:
- GO-2026-4601 / CVE-2026-25679: invalid URL validation in net/url
- GO-2026-4602 / CVE-2026-27139: directory traversal in os.File.ReadDir
- GO-2026-4603 / CVE-2026-27142: XSS in html/template meta content attribute